### PR TITLE
Refactor add_statement to simplify the code considerably

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 
@@ -33,4 +36,7 @@ Metrics/MethodLength:
   Enabled: false
 
 Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
   Enabled: false

--- a/lib/wikidatum/client.rb
+++ b/lib/wikidatum/client.rb
@@ -92,14 +92,15 @@ class Wikidatum::Client
   # @example
   #   wikidatum_client.add_statement(
   #     id: 'Q123',
-  #     statement: {},
+  #     property: 'P23',
+  #     datavalue: Wikidatum::DataValueType::String.new(string: 'Foo'),
   #     comment: 'Adding something or another.'
   #   )
   #
   # @param id [String] the ID of the item on which the statement will be added.
   # @param property [String] property ID in the format 'P123'.
   # @param datavalue [Wikidatum::DataValueType::GlobeCoordinate, Wikidatum::DataValueType::MonolingualText, Wikidatum::DataValueType::Quantity, Wikidatum::DataValueType::String, Wikidatum::DataValueType::Time, Wikidatum::DataValueType::WikibaseEntityId, Wikidatum::DataValueType::NoValue, Wikidatum::DataValueType::SomeValue] the datavalue of the statement being created.
-  # @param datatype [String, nil] if nil, it'll determine the type based on what was passed for the statement argument. This may differ from the type of the Statement's datavalue (for example with the 'url' type)
+  # @param datatype [String, nil] if nil, it'll determine the type based on what was passed for the statement argument. This may differ from the type of the Statement's datavalue (for example with the 'url' type).
   # @param qualifiers [Hash<String, Array<Wikidatum::Snak>>]
   # @param references [Array<Wikidatum::Reference>]
   # @param rank [String]
@@ -111,16 +112,26 @@ class Wikidatum::Client
 
     id = coerce_item_id(id)
 
+    # Unless datatype is set explicitly by the caller, just assume it's identical to the wikibase_type.
     datatype ||= datavalue.wikibase_type
 
     case datavalue.class.to_s
     when 'Wikidatum::DataValueType::NoValue'
       statement_hash = {
-
+        mainsnak: {
+          snaktype: 'novalue',
+          property: property,
+          datatype: datatype
+        }
       }
     when 'Wikidatum::DataValueType::SomeValue'
-      # extra thing to make rubocop shut up for now.
-      statement_hash = { foo: :bar }
+      statement_hash = {
+        mainsnak: {
+          snaktype: 'somevalue',
+          property: property,
+          datatype: datatype
+        }
+      }
     when 'Wikidatum::DataValueType::GlobeCoordinate', 'Wikidatum::DataValueType::MonolingualText', 'Wikidatum::DataValueType::Quantity', 'Wikidatum::DataValueType::String', 'Wikidatum::DataValueType::Time', 'Wikidatum::DataValueType::WikibaseEntityId'
       statement_hash = {
         mainsnak: {

--- a/lib/wikidatum/client.rb
+++ b/lib/wikidatum/client.rb
@@ -112,8 +112,9 @@ class Wikidatum::Client
 
     id = coerce_item_id(id)
 
-    # Unless datatype is set explicitly by the caller, just assume it's identical to the wikibase_type.
-    datatype ||= datavalue.wikibase_type
+    # Unless datatype is set explicitly by the caller, just assume we can pull the
+    # default from the datavalue class.
+    datatype ||= datavalue.wikibase_datatype
 
     case datavalue.class.to_s
     when 'Wikidatum::DataValueType::NoValue'

--- a/lib/wikidatum/data_value_type/base.rb
+++ b/lib/wikidatum/data_value_type/base.rb
@@ -28,10 +28,9 @@ module Wikidatum::DataValueType
     # @return [DataValueType::GlobeCoordinate, DataValueType::MonolingualText, DataValueType::Quantity, DataValueType::String, DataValueType::Time, DataValueType::WikibaseEntityId, nil]
     attr_reader :value
 
-    # @!visibility private
-    #
     # @param type [Symbol]
-    # @param value [DataValueType::GlobeCoordinate, DataValueType::MonolingualText, DataValueType::Quantity, DataValueType::String, DataValueType::Time, DataValueType::WikibaseEntityId, nil]
+    # @param value [DataValueType::GlobeCoordinate, DataValueType::MonolingualText, DataValueType::Quantity, DataValueType::String, DataValueType::Time, DataValueType::WikibaseEntityId, nil] nil if type is no_value or some_value
+    # @return [void]
     def initialize(type:, value:)
       @type = type
       @value = value

--- a/lib/wikidatum/data_value_type/globe_coordinate.rb
+++ b/lib/wikidatum/data_value_type/globe_coordinate.rb
@@ -2,7 +2,7 @@
 
 require 'wikidatum/data_value_type/base'
 
-# The Monolingual Text type datavalue JSON looks like this:
+# The Globe Coordinate type datavalue JSON looks like this:
 #
 # ```json
 # {
@@ -56,7 +56,15 @@ class Wikidatum::DataValueType::GlobeCoordinate
   #
   # @return [String]
   def wikibase_type
-    'globalcoordinate'
+    'globecoordinate'
+  end
+
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    'globe-coordinate' # yes, really
   end
 
   # @!visibility private

--- a/lib/wikidatum/data_value_type/globe_coordinate.rb
+++ b/lib/wikidatum/data_value_type/globe_coordinate.rb
@@ -30,7 +30,11 @@ class Wikidatum::DataValueType::GlobeCoordinate
   # @return [String] A URL (usually in the same Wikibase instance) representing the given globe model (e.g. Earth).
   attr_reader :globe
 
-  # @!visibility private
+  # @param latitude [Float]
+  # @param longitude [Float]
+  # @param precision [Float]
+  # @param globe [String]
+  # @return [void]
   def initialize(latitude:, longitude:, precision:, globe:)
     @latitude = latitude
     @longitude = longitude

--- a/lib/wikidatum/data_value_type/globe_coordinate.rb
+++ b/lib/wikidatum/data_value_type/globe_coordinate.rb
@@ -67,4 +67,14 @@ class Wikidatum::DataValueType::GlobeCoordinate
       )
     )
   end
+
+  # @!visibility private
+  def marshal_dump
+    {
+      latitude: @latitude,
+      longitude: @longitude,
+      precision: @precision,
+      globe: @globe
+    }
+  end
 end

--- a/lib/wikidatum/data_value_type/monolingual_text.rb
+++ b/lib/wikidatum/data_value_type/monolingual_text.rb
@@ -45,6 +45,14 @@ class Wikidatum::DataValueType::MonolingualText
     'monolingualtext'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(data_value_json)
     Wikidatum::DataValueType::Base.new(

--- a/lib/wikidatum/data_value_type/monolingual_text.rb
+++ b/lib/wikidatum/data_value_type/monolingual_text.rb
@@ -53,4 +53,12 @@ class Wikidatum::DataValueType::MonolingualText
       )
     )
   end
+
+  # @!visibility private
+  def marshal_dump
+    {
+      language: @language,
+      text: @text
+    }
+  end
 end

--- a/lib/wikidatum/data_value_type/monolingual_text.rb
+++ b/lib/wikidatum/data_value_type/monolingual_text.rb
@@ -22,7 +22,9 @@ class Wikidatum::DataValueType::MonolingualText
   # @return [String]
   attr_reader :text
 
-  # @!visibility private
+  # @param language [String]
+  # @param text [String]
+  # @return [void]
   def initialize(language:, text:)
     @language = language
     @text = text

--- a/lib/wikidatum/data_value_type/no_value.rb
+++ b/lib/wikidatum/data_value_type/no_value.rb
@@ -7,6 +7,13 @@ require 'wikidatum/data_value_type/base'
 
 # Represents "no value".
 class Wikidatum::DataValueType::NoValue < Wikidatum::DataValueType::Base
+  # The "type" value used by Wikibase, for use when creating/updating statements.
+  #
+  # @return [String]
+  def wikibase_type
+    'string'
+  end
+
   # @!visibility private
   def self.marshal_load(_data_value_json)
     new(type: :no_value, value: nil)

--- a/lib/wikidatum/data_value_type/no_value.rb
+++ b/lib/wikidatum/data_value_type/no_value.rb
@@ -14,6 +14,14 @@ class Wikidatum::DataValueType::NoValue < Wikidatum::DataValueType::Base
     'string'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(_data_value_json)
     new(type: :no_value, value: nil)

--- a/lib/wikidatum/data_value_type/quantity.rb
+++ b/lib/wikidatum/data_value_type/quantity.rb
@@ -59,6 +59,14 @@ class Wikidatum::DataValueType::Quantity
     'quantity'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(data_value_json)
     Wikidatum::DataValueType::Base.new(

--- a/lib/wikidatum/data_value_type/quantity.rb
+++ b/lib/wikidatum/data_value_type/quantity.rb
@@ -72,8 +72,8 @@ class Wikidatum::DataValueType::Quantity
   def marshal_dump
     {
       amount: @amount,
-      'upperBound': @upper_bound,
-      'lowerBound': @lower_bound,
+      upperBound: @upper_bound,
+      lowerBound: @lower_bound,
       unit: @unit
     }
   end

--- a/lib/wikidatum/data_value_type/quantity.rb
+++ b/lib/wikidatum/data_value_type/quantity.rb
@@ -67,4 +67,14 @@ class Wikidatum::DataValueType::Quantity
       )
     )
   end
+
+  # @!visibility private
+  def marshal_dump
+    {
+      amount: @amount,
+      'upperBound': @upper_bound,
+      'lowerBound': @lower_bound,
+      unit: @unit
+    }
+  end
 end

--- a/lib/wikidatum/data_value_type/quantity.rb
+++ b/lib/wikidatum/data_value_type/quantity.rb
@@ -30,7 +30,11 @@ class Wikidatum::DataValueType::Quantity
   # @return [String] a URL describing the unit for this quantity, e.g. "meter", "kilometer", "pound", "chapter", "section", etc.
   attr_reader :unit
 
-  # @!visibility private
+  # @param amount [String]
+  # @param upper_bound [String]
+  # @param lower_bound [String]
+  # @param unit [String]
+  # @return [void]
   def initialize(amount:, upper_bound:, lower_bound:, unit:)
     @amount = amount
     @upper_bound = upper_bound

--- a/lib/wikidatum/data_value_type/some_value.rb
+++ b/lib/wikidatum/data_value_type/some_value.rb
@@ -7,6 +7,13 @@ require 'wikidatum/data_value_type/base'
 
 # Represents a value of "unknown value".
 class Wikidatum::DataValueType::SomeValue < Wikidatum::DataValueType::Base
+  # The "type" value used by Wikibase, for use when creating/updating statements.
+  #
+  # @return [String]
+  def wikibase_type
+    'string'
+  end
+
   # @!visibility private
   def self.marshal_load(_data_value_json)
     new(type: :some_value, value: nil)

--- a/lib/wikidatum/data_value_type/some_value.rb
+++ b/lib/wikidatum/data_value_type/some_value.rb
@@ -14,6 +14,14 @@ class Wikidatum::DataValueType::SomeValue < Wikidatum::DataValueType::Base
     'string'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(_data_value_json)
     new(type: :some_value, value: nil)

--- a/lib/wikidatum/data_value_type/string.rb
+++ b/lib/wikidatum/data_value_type/string.rb
@@ -44,4 +44,9 @@ class Wikidatum::DataValueType::String
       )
     )
   end
+
+  # @!visibility private
+  def marshal_dump
+    @string
+  end
 end

--- a/lib/wikidatum/data_value_type/string.rb
+++ b/lib/wikidatum/data_value_type/string.rb
@@ -16,7 +16,8 @@ class Wikidatum::DataValueType::String
   # @return [String] the value for the string.
   attr_reader :string
 
-  # @!visibility private
+  # @param string [String]
+  # @return [void]
   def initialize(string:)
     @string = string
   end

--- a/lib/wikidatum/data_value_type/string.rb
+++ b/lib/wikidatum/data_value_type/string.rb
@@ -36,6 +36,14 @@ class Wikidatum::DataValueType::String
     'string'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(string)
     Wikidatum::DataValueType::Base.new(

--- a/lib/wikidatum/data_value_type/time.rb
+++ b/lib/wikidatum/data_value_type/time.rb
@@ -120,6 +120,14 @@ class Wikidatum::DataValueType::Time
     'time'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    wikibase_type
+  end
+
   # @!visibility private
   def self.marshal_load(data_value_json)
     Wikidatum::DataValueType::Base.new(

--- a/lib/wikidatum/data_value_type/time.rb
+++ b/lib/wikidatum/data_value_type/time.rb
@@ -129,6 +129,16 @@ class Wikidatum::DataValueType::Time
     )
   end
 
+  # @!visibility private
+  def marshal_dump
+    {
+      time: @time,
+      timezone: @time_zone,
+      precision: @precision,
+      calendarmodel: @calendar_model
+    }
+  end
+
   PRETTY_PRECISIONS = {
     0 => :gigayear,
     1 => :'100_megayear',

--- a/lib/wikidatum/data_value_type/time.rb
+++ b/lib/wikidatum/data_value_type/time.rb
@@ -90,7 +90,11 @@ class Wikidatum::DataValueType::Time
   # @return [String] a URL (usually in the same Wikibase instance) representing the given calendar model (e.g. Gregorian, Julian).
   attr_reader :calendar_model
 
-  # @!visibility private
+  # @param time [String]
+  # @param time_zone [Integer]
+  # @param precision [Integer]
+  # @param calendar_model [String]
+  # @return [void]
   def initialize(time:, time_zone:, precision:, calendar_model:)
     @time = time
     @time_zone = time_zone

--- a/lib/wikidatum/data_value_type/wikibase_entity_id.rb
+++ b/lib/wikidatum/data_value_type/wikibase_entity_id.rb
@@ -26,6 +26,10 @@ class Wikidatum::DataValueType::WikibaseEntityId
   # @return [String] in the format "Q123".
   attr_reader :id
 
+  # @param entity_type [String]
+  # @param numeric_id [Integer]
+  # @param id [String]
+  # @return [void]
   def initialize(entity_type:, numeric_id:, id:)
     @entity_type = entity_type
     @numeric_id = numeric_id

--- a/lib/wikidatum/data_value_type/wikibase_entity_id.rb
+++ b/lib/wikidatum/data_value_type/wikibase_entity_id.rb
@@ -52,6 +52,14 @@ class Wikidatum::DataValueType::WikibaseEntityId
     'wikibase-entityid'
   end
 
+  # The "datatype" value used by Wikibase, usually identical to wikibase_type
+  # but not always.
+  #
+  # @return [String]
+  def wikibase_datatype
+    'wikibase-item' # yes, really
+  end
+
   # @!visibility private
   def self.marshal_load(data_value_json)
     Wikidatum::DataValueType::Base.new(

--- a/lib/wikidatum/data_value_type/wikibase_entity_id.rb
+++ b/lib/wikidatum/data_value_type/wikibase_entity_id.rb
@@ -59,4 +59,13 @@ class Wikidatum::DataValueType::WikibaseEntityId
       )
     )
   end
+
+  # @!visibility private
+  def marshal_dump
+    {
+      'entity-type': @entity_type,
+      'numeric-id': @numeric_id,
+      id: @id
+    }
+  end
 end

--- a/lib/wikidatum/snak.rb
+++ b/lib/wikidatum/snak.rb
@@ -25,7 +25,7 @@ class Wikidatum::Snak
   # @param snaktype [String]
   # @param property [String] ID of the property for this Snak, in the format 'P123'.
   # @param datatype [String]
-  # @param datavalue [?] TODO: Not sure what this is yet.
+  # @param datavalue [DataValueType::GlobeCoordinate, DataValueType::MonolingualText, DataValueType::Quantity, DataValueType::String, DataValueType::Time, DataValueType::WikibaseEntityId]
   def initialize(hash:, snaktype:, property:, datatype:, datavalue:)
     @hash = hash
     @snaktype = snaktype

--- a/test/wikidatum/client_spec.rb
+++ b/test/wikidatum/client_spec.rb
@@ -112,78 +112,278 @@ describe Wikidatum::Client do
   describe '#add_statement' do
     let(:item_id) { 'Q124' }
     let(:property) { 'P625' }
-    let(:datatype) { nil }
-    let(:datavalue) { Wikidatum::DataValueType::String.new(string: 'test data') }
 
-    let(:output_body) do
-      {
-        statement: {
-          mainsnak: {
-            snaktype: "value",
-            property: "P625",
-            datatype: "string",
-            datavalue: {
-              type: "string",
-              value: "test data"
-            }
-          },
-          qualifiers: {},
-          references: [],
-          rank: "normal",
-          type: "statement"
+    describe 'creating a string-type statement' do
+      let(:datavalue) { Wikidatum::DataValueType::String.new(string: 'test data') }
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "string",
+              datavalue: {
+                type: "string",
+                value: "test data"
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
         }
-      }
-    end
+      end
 
-    before do
-      stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
-        .with(body: output_body.merge({ bot: true }).to_json)
-        .to_return(status: 200, body: '', headers: {})
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
 
-      stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
-        .with(body: output_body.merge({ bot: true, tags: ['bar'], comment: 'adding string property' }).to_json)
-        .to_return(status: 200, body: '', headers: {})
-    end
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true, tags: ['bar'], comment: 'adding string property' }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
 
-    it 'raises when given an invalid item ID' do
-      assert_raises(ArgumentError, "'bad id' is an invalid Wikibase QID. Must be an integer, a string representation of an integer, or in the format 'Q123'.") do
-        create_client.add_statement(id: 'bad id')
+      it 'raises when given an invalid item ID' do
+        assert_raises(ArgumentError, "'bad id' is an invalid Wikibase QID. Must be an integer, a string representation of an integer, or in the format 'Q123'.") do
+          create_client.add_statement(id: 'bad id')
+        end
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
+
+      it 'returns true when passed an integer for id' do
+        response = create_client.add_statement(
+          id: 124,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
+
+      it 'returns true when also sending tags and a comment' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue,
+          tags: ['bar'],
+          comment: 'adding string property'
+        )
+
+        assert response
       end
     end
 
-    it 'returns true' do
-      response = create_client.add_statement(
-        id: item_id,
-        property: property,
-        datavalue: datavalue,
-        datatype: datatype
-      )
+    describe 'creating a time-type statement' do
+      let(:datavalue) do
+        Wikidatum::DataValueType::Time.new(
+          time: '+2022-08-12T00:00:00Z',
+          time_zone: 0,
+          precision: 11,
+          calendar_model: 'https://wikidata.org/wiki/Q1234'
+        )
+      end
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "time",
+              datavalue: {
+                type: "time",
+                value: {
+                  time: '+2022-08-12T00:00:00Z',
+                  timezone: 0,
+                  precision: 11,
+                  calendarmodel: 'https://wikidata.org/wiki/Q1234'
+                }
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
+        }
+      end
 
-      assert response
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
     end
 
-    it 'returns true when passed an integer for id' do
-      response = create_client.add_statement(
-        id: 124,
-        property: property,
-        datavalue: datavalue,
-        datatype: datatype
-      )
+    describe 'creating a quantity-type statement' do
+      let(:datavalue) do
+        Wikidatum::DataValueType::Quantity.new(
+          amount: '+1',
+          upper_bound: nil,
+          lower_bound: nil,
+          unit: 'https://wikidata.org/wiki/Q1234'
+        )
+      end
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "quantity",
+              datavalue: {
+                type: "quantity",
+                value: {
+                  amount: '+1',
+                  upperBound: nil,
+                  lowerBound: nil,
+                  unit: 'https://wikidata.org/wiki/Q1234'
+                }
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
+        }
+      end
 
-      assert response
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
     end
 
-    it 'returns true when also sending tags and a comment' do
-      response = create_client.add_statement(
-        id: item_id,
-        property: property,
-        datavalue: datavalue,
-        datatype: datatype,
-        tags: ['bar'],
-        comment: 'adding string property'
-      )
+    describe 'creating a Wikibase Entity ID-type statement' do
+      let(:datavalue) do
+        Wikidatum::DataValueType::WikibaseEntityId.new(
+          entity_type: 'item',
+          numeric_id: 1234,
+          id: 'Q1234'
+        )
+      end
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "wikibase-item",
+              datavalue: {
+                type: "wikibase-entityid",
+                value: {
+                  'entity-type': "item",
+                  'numeric-id': 1234,
+                  id: "Q1234"
+                }
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
+        }
+      end
 
-      assert response
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
+    end
+
+    describe 'creating a GlobeCoordinate-type statement' do
+      let(:datavalue) do
+        Wikidatum::DataValueType::GlobeCoordinate.new(
+          latitude: 52.516666666667,
+          longitude: 13.383333333333,
+          precision: 0.016666666666667,
+          globe: 'https://wikidata.org/wiki/Q2'
+        )
+      end
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "globe-coordinate",
+              datavalue: {
+                type: "globecoordinate",
+                value: {
+                  latitude: 52.516666666667,
+                  longitude: 13.383333333333,
+                  precision: 0.016666666666667,
+                  globe: 'https://wikidata.org/wiki/Q2'
+                }
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
+        }
+      end
+
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
     end
   end
 end

--- a/test/wikidatum/client_spec.rb
+++ b/test/wikidatum/client_spec.rb
@@ -286,6 +286,53 @@ describe Wikidatum::Client do
       end
     end
 
+    describe 'creating a monolingualtext-type statement' do
+      let(:datavalue) do
+        Wikidatum::DataValueType::MonolingualText.new(
+          language: 'en',
+          text: 'Foobar'
+        )
+      end
+      let(:output_body) do
+        {
+          statement: {
+            mainsnak: {
+              snaktype: "value",
+              property: "P625",
+              datatype: "monolingualtext",
+              datavalue: {
+                type: "monolingualtext",
+                value: {
+                  language: 'en',
+                  text: 'Foobar'
+                }
+              }
+            },
+            qualifiers: {},
+            references: [],
+            rank: "normal",
+            type: "statement"
+          }
+        }
+      end
+
+      before do
+        stub_request(:post, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/statements")
+          .with(body: output_body.merge({ bot: true }).to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'returns true' do
+        response = create_client.add_statement(
+          id: item_id,
+          property: property,
+          datavalue: datavalue
+        )
+
+        assert response
+      end
+    end
+
     describe 'creating a Wikibase Entity ID-type statement' do
       let(:datavalue) do
         Wikidatum::DataValueType::WikibaseEntityId.new(

--- a/test/wikidatum/client_spec.rb
+++ b/test/wikidatum/client_spec.rb
@@ -111,19 +111,9 @@ describe Wikidatum::Client do
 
   describe '#add_statement' do
     let(:item_id) { 'Q124' }
-    let(:input_body) do
-      {
-        mainsnak: {
-          snaktype: "value",
-          property: "P625",
-          datatype: "string",
-          datavalue: {
-            type: "string",
-            value: "test data"
-          }
-        }
-      }
-    end
+    let(:property) { 'P625' }
+    let(:datatype) { nil }
+    let(:datavalue) { Wikidatum::DataValueType::String.new(string: 'test data') }
 
     let(:output_body) do
       {
@@ -162,19 +152,33 @@ describe Wikidatum::Client do
     end
 
     it 'returns true' do
-      response = create_client.add_statement(id: item_id, statement: input_body)
+      response = create_client.add_statement(
+        id: item_id,
+        property: property,
+        datavalue: datavalue,
+        datatype: datatype
+      )
+
       assert response
     end
 
-    it 'returns true when passed an integer' do
-      response = create_client.add_statement(id: 124, statement: input_body)
+    it 'returns true when passed an integer for id' do
+      response = create_client.add_statement(
+        id: 124,
+        property: property,
+        datavalue: datavalue,
+        datatype: datatype
+      )
+
       assert response
     end
 
     it 'returns true when also sending tags and a comment' do
       response = create_client.add_statement(
         id: item_id,
-        statement: input_body,
+        property: property,
+        datavalue: datavalue,
+        datatype: datatype,
         tags: ['bar'],
         comment: 'adding string property'
       )


### PR DESCRIPTION
This is how adding a statement works before and after this refactor:

```rb
# Before refactor:
client.add_statement(
  id: 'Q124',
  statement: {
    mainsnak: {
      snaktype: "value",
      property: "P123",
      datatype: "string",
      datavalue: {
        type: "string",
        value: "Foo"
      }
    }
  }
)

# After refactor:
client.add_statement(
  id: 'Q124',
  property: 'P123',
  datavalue: DataValueType::String.new(string: 'Foo')
)
```

This is a lot better :D 

Now everything is mostly abstracted away and the user only needs to care about the property, the datavalue type they want to use, and how to instantiate the DataValueType subclass.