### PR TITLE
Add `labels` endpoint support

### DIFF
--- a/lib/wikidatum/client.rb
+++ b/lib/wikidatum/client.rb
@@ -112,6 +112,28 @@ module Wikidatum
       Wikidatum::Item.marshal_load(response)
     end
 
+    # Get labels for an item from the Wikibase API based on the item's QID.
+    #
+    # @example
+    #   wikidatum_client.labels(id: 'Q123') #=> [<Wikidatum::Term lang="en" value="Foo">, <Wikidatum::Term lang="es" value="Bar">]
+    #   wikidatum_client.labels(id: 123)
+    #   wikidatum_client.labels(id: '123')
+    #
+    # @param id [String, Integer] Either a string or integer representation of
+    #   the relevant item's QID, e.g. `"Q123"`, `"123"`, or `123`.
+    # @return [Array<Wikidatum::Term>] This can, theoretically, be empty if the item has no labels.
+    def labels(id:)
+      raise ArgumentError, "#{id.inspect} is an invalid Wikibase QID. Must be an integer, a string representation of an integer, or in the format 'Q123'." unless id.is_a?(Integer) || id.match?(ITEM_REGEX)
+
+      id = coerce_item_id(id)
+
+      response = get_request("/entities/items/#{id}/labels")
+
+      puts JSON.pretty_generate(response) if ENV['DEBUG']
+
+      response.to_a.map { |lang, val| Wikidatum::Term.new(lang: lang, value: val) }
+    end
+
     # Get a statement from the Wikibase API based on its ID.
     #
     # @example

--- a/test/wikidatum/client_spec.rb
+++ b/test/wikidatum/client_spec.rb
@@ -59,12 +59,20 @@ describe Wikidatum::Client do
 
   describe '#labels' do
     let(:item_id) { 'Q124' }
+    let(:item2_id) { 'Q125' }
 
     before do
       stub_request(:get, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item_id}/labels")
         .to_return(
           status: 200,
           body: { en: 'Foo', es: 'Bar' }.to_json,
+          headers: {}
+        )
+
+      stub_request(:get, "https://example.com/w/rest.php/wikibase/v0/entities/items/#{item2_id}/labels")
+        .to_return(
+          status: 200,
+          body: {}.to_json,
           headers: {}
         )
     end
@@ -93,6 +101,11 @@ describe Wikidatum::Client do
     it 'returns a valid array of labels when passing a stringified integer' do
       labels = create_client.labels(id: '124')
       labels.each { |label| assert_kind_of Wikidatum::Term, label }
+    end
+
+    it 'returns an empty array when the item has no labels' do
+      labels = create_client.labels(id: item2_id)
+      assert_empty labels
     end
   end
 


### PR DESCRIPTION
This was recently added to the REST API, so this adds support for it.